### PR TITLE
Add banner to notify users that name registration is disabled

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,7 @@
+dependenciesMeta:
+  tiny-secp256k1:
+    built: false
+
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-typescript.cjs
     spec: "@yarnpkg/plugin-typescript"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,7 +1,3 @@
-dependenciesMeta:
-  tiny-secp256k1:
-    built: false
-
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-typescript.cjs
     spec: "@yarnpkg/plugin-typescript"

--- a/components/registration-disabled-banner/index.tsx
+++ b/components/registration-disabled-banner/index.tsx
@@ -1,0 +1,35 @@
+import { FunctionComponent } from "react";
+import styled from "styled-components";
+import color from "../../styles/color";
+
+export const RegistrationDisabledBanner: FunctionComponent = () => {
+  return (
+    <BannerContainer>
+      <BannerText>
+        Registering new ICNS names is no longer available.
+      </BannerText>
+    </BannerContainer>
+  );
+};
+
+const BannerContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 100%;
+  padding: 0.75rem 1rem;
+
+  background-color: ${color.orange["100"]};
+`;
+
+const BannerText = styled.span`
+  font-family: "Inter", serif;
+  font-weight: 600;
+  font-size: 0.875rem;
+  line-height: 1rem;
+  letter-spacing: 0.02em;
+
+  color: ${color.white};
+  text-align: center;
+`;

--- a/components/registration-disabled-banner/index.tsx
+++ b/components/registration-disabled-banner/index.tsx
@@ -6,7 +6,7 @@ export const RegistrationDisabledBanner: FunctionComponent = () => {
   return (
     <BannerContainer>
       <BannerText>
-        Registering new ICNS names is no longer available.
+        ICNS registration is closed. Names you already own are unaffected.
       </BannerText>
     </BannerContainer>
   );

--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
     "semver": "^7.3.8",
     "styled-components": "^5.3.6"
   },
+  "dependenciesMeta": {
+    "tiny-secp256k1": {
+      "built": false
+    }
+  },
   "devDependencies": {
     "@next/eslint-plugin-next": "^13.0.5",
     "@svgr/webpack": "^6.5.1",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/router";
 import React, { useEffect, useMemo } from "react";
 import { DefaultTheme, ThemeProvider } from "styled-components";
 import ErrorBoundary from "../components/error-boundary";
+import { RegistrationDisabledBanner } from "../components/registration-disabled-banner";
 import color from "../styles/color";
 
 import { GlobalStyle } from "../styles/global";
@@ -61,6 +62,7 @@ export default function App({ Component, pageProps }: AppProps) {
       </Head>
       <React.Fragment>
         <GlobalStyle />
+        <RegistrationDisabledBanner />
         <ErrorBoundary>
           <Component {...pageProps} />
         </ErrorBoundary>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -106,7 +106,7 @@ export default function Home() {
 
           <CTAContainer>
             <ConnectButtonContainer>
-              <PrimaryButton onClick={onClickConnectWalletButton}>
+              <PrimaryButton disabled>
                 Claim Now
               </PrimaryButton>
             </ConnectButtonContainer>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -106,9 +106,7 @@ export default function Home() {
 
           <CTAContainer>
             <ConnectButtonContainer>
-              <PrimaryButton disabled>
-                Claim Now
-              </PrimaryButton>
+              <PrimaryButton disabled>Claim Now</PrimaryButton>
             </ConnectButtonContainer>
             <ICNSDescription>
               ICNS allows you to use easy-to-remember names instead of

--- a/yarn.lock
+++ b/yarn.lock
@@ -5294,6 +5294,9 @@ __metadata:
     semver: ^7.3.8
     styled-components: ^5.3.6
     typescript: 4.9.3
+  dependenciesMeta:
+    tiny-secp256k1:
+      built: false
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Display a persistent, non-dismissible banner at the top of every page informing users that registering new ICNS names is no longer available.